### PR TITLE
PDQ-16620 django32 upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ examples/logs/
 examples/media/
 examples/static/
 examples/example/local_settings.py
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ examples/media/
 examples/static/
 examples/example/local_settings.py
 .idea/
+.tox/

--- a/axes/decorators.py
+++ b/axes/decorators.py
@@ -9,7 +9,7 @@ from django.contrib.auth import logout
 from django.core.exceptions import ObjectDoesNotExist
 from django.http import HttpResponse
 from django.http import HttpResponseRedirect
-from django.shortcuts import render_to_response
+from django.shortcuts import render
 from django.template import RequestContext
 from django.utils import timezone as datetime
 from django.utils.translation import ugettext_lazy
@@ -32,7 +32,6 @@ from axes.models import AccessLog
 from axes.models import AccessAttempt
 from axes.signals import user_locked_out
 import axes
-from django.utils import six
 
 
 # see if the user has overridden the failure limit
@@ -169,7 +168,7 @@ def query2str(items, max_length=1024):
     kvs = []
     for k, v in items:
         if k != PASSWORD_FORM_FIELD:
-            kvs.append(six.u('%s=%s') % (k, v))
+            kvs.append('%s=%s' % (k, v))
 
     return '\n'.join(kvs)[:max_length]
 
@@ -335,7 +334,7 @@ def watch_login(func):
                 trusted=not login_unsuccessful,
             )
             if check_request(request, login_unsuccessful):
-                return response
+                 return response
 
             return lockout_response(request)
 
@@ -351,8 +350,7 @@ def lockout_response(request):
             'failure_limit': FAILURE_LIMIT,
             'username': request.POST.get(USERNAME_FORM_FIELD, '')
         }
-        return render_to_response(LOCKOUT_TEMPLATE, context,
-                                  context_instance=RequestContext(request))
+        return render(request, LOCKOUT_TEMPLATE, context)
 
     LOCKOUT_URL = get_lockout_url()
     if LOCKOUT_URL:

--- a/axes/middleware.py
+++ b/axes/middleware.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.contrib.auth import views as auth_views
+from django.utils.decorators import method_decorator
 from django.utils.deprecation import MiddlewareMixin
 
 from axes.decorators import watch_login
@@ -9,8 +10,11 @@ class FailedLoginMiddleware(MiddlewareMixin):
     def __init__(self, *args, **kwargs):
         super(FailedLoginMiddleware, self).__init__(*args, **kwargs)
 
+        @method_decorator(watch_login, name='dispatch')
+        class LoginView(auth_views.LoginView):
+            pass
         # watch the auth login
-        auth_views.login = watch_login(auth_views.login)
+        auth_views.LoginView = LoginView
 
 
 class ViewDecoratorMiddleware(MiddlewareMixin):
@@ -19,7 +23,7 @@ class ViewDecoratorMiddleware(MiddlewareMixin):
     django.auth.views.login.
 
     This middleware allows adding protection to other views without the need
-    to change any urls or dectorate them manually.
+    to change any urls or decorate them manually.
 
     Add this middleware to your MIDDLEWARE settings after
     `axes.middleware.FailedLoginMiddleware` and before the django

--- a/axes/models.py
+++ b/axes/models.py
@@ -1,5 +1,4 @@
 from django.db import models
-from django.utils import six
 
 class CommonAccess(models.Model):
     user_agent = models.CharField(
@@ -59,7 +58,7 @@ class AccessAttempt(CommonAccess):
         return self.failures_since_start
 
     def __unicode__(self):
-        return six.u('Attempted Access: %s') % self.attempt_time
+        return 'Attempted Access: %s' % self.attempt_time
 
 
 class AccessLog(CommonAccess):
@@ -69,4 +68,4 @@ class AccessLog(CommonAccess):
     )
 
     def __unicode__(self):
-        return six.u('Access Log for %s @ %s') % (self.username, self.attempt_time)
+        return 'Access Log for %s @ %s' % (self.username, self.attempt_time)

--- a/axes/test_settings.py
+++ b/axes/test_settings.py
@@ -9,10 +9,27 @@ DATABASES = {
 
 SITE_ID = 1
 
-MIDDLEWARE_CLASSES = (
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.template.context_processors.debug',
+                'django.template.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        },
+    },
+]
+
+MIDDLEWARE = (
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
     'axes.middleware.FailedLoginMiddleware'
 )
 
@@ -35,3 +52,4 @@ LOGIN_REDIRECT_URL = '/admin/'
 
 AXES_LOGIN_FAILURE_LIMIT = 10
 AXES_COOLOFF_TIME = timedelta(seconds=2)
+AXES_VERBOSE = True

--- a/axes/test_urls.py
+++ b/axes/test_urls.py
@@ -1,6 +1,6 @@
-from django.conf.urls import patterns, include
+from django.conf.urls import url
 from django.contrib import admin
 
-urlpatterns = patterns('',
-    (r'^admin/', include(admin.site.urls)),
-)
+urlpatterns = [
+    url(r'^admin/', admin.site.urls),
+]

--- a/axes/tests.py
+++ b/axes/tests.py
@@ -4,8 +4,7 @@ import time
 
 from django.test import TestCase
 from django.contrib.auth.models import User
-from django.core.urlresolvers import NoReverseMatch
-from django.core.urlresolvers import reverse
+from django.urls import reverse, NoReverseMatch
 
 from axes.decorators import COOLOFF_TIME
 from axes.decorators import FAILURE_LIMIT
@@ -19,7 +18,7 @@ class AccessAttemptTest(TestCase):
     """
     VALID_PASSWORD = 'valid-password'
     LOCKED_MESSAGE = 'Account locked: too many login attempts.'
-    LOGIN_FORM_KEY = '<input type="submit" value="Log in" />'
+    LOGIN_FORM_KEY = '<input type="submit" value="Log in">'
 
     def _login(self, is_valid=False, user_agent='test-browser'):
         """Login a user. A valid credential is used when is_valid is True,

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 import os
 from setuptools import setup, find_packages
 
-VERSION = '1.4.3'
+VERSION = '1.4.4'
 
 setup(
     name='django-axes',

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,27 @@
+[tox]
+envlist =
+    py{38,39}-{django22,django32}
+
+[testenv]
+deps =
+    django22: Django>=2.0,<3
+    django32: Django>=3.2,<4
+allowlist_externals = ls
+commands =
+    django-admin.py check
+;    by some reason tests only worked running it individually
+    django-admin.py test axes.tests.AccessAttemptTest.test_send_lockout_signal
+    django-admin.py test axes.tests.AccessAttemptTest.test_cooling_off_for_trusted_user
+    django-admin.py test axes.tests.AccessAttemptTest.test_failure_limit_many
+    django-admin.py test axes.tests.AccessAttemptTest.test_failure_limit_once
+    django-admin.py test axes.tests.AccessAttemptTest.test_reset_all
+    django-admin.py test axes.tests.AccessAttemptTest.test_reset_ip
+    django-admin.py test axes.tests.AccessAttemptTest.test_send_lockout_signal
+    django-admin.py test axes.tests.AccessAttemptTest.test_valid_login
+    django-admin.py test axes.tests.AccessAttemptTest.test_valid_logout
+    django-admin.py test axes.tests.AccessAttemptTest.test_cooling_off
+    django-admin.py test axes.tests.AccessAttemptTest.test_long_user_agent_valid
+    django-admin.py test axes.tests.AccessAttemptTest.test_long_user_agent_not_valid
+setenv =
+    DJANGO_SETTINGS_MODULE=axes.test_settings
+    PYTHONPATH={toxinidir}


### PR DESCRIPTION
The django wrapper for axes was is no longer supported. Because of that we have our own fork.

We need to make it support Django 3.2.

Note:
Added tox in order to help with tests. But for some reason (I can't figure it out) the suite was not executed properly so
I added commands for running it individually. All tests has passed after refactoring with django22 and djnago32